### PR TITLE
Async azure logging + tqdm postfix conflict

### DIFF
--- a/corebehrt/azure/log.py
+++ b/corebehrt/azure/log.py
@@ -6,6 +6,7 @@ try:
     # Try to import mlflow and set availability flag
     import mlflow
     import os
+
     os.environ["MLFLOW_ENABLE_ASYNC_LOGGING"] = True
 
     MLFLOW_AVAILABLE = True

--- a/corebehrt/azure/log.py
+++ b/corebehrt/azure/log.py
@@ -5,6 +5,8 @@ MLFLOW_AVAILABLE = False
 try:
     # Try to import mlflow and set availability flag
     import mlflow
+    import os
+    os.environ["MLFLOW_ENABLE_ASYNC_LOGGING"] = True
 
     MLFLOW_AVAILABLE = True
 except:

--- a/corebehrt/modules/trainer/trainer.py
+++ b/corebehrt/modules/trainer/trainer.py
@@ -183,7 +183,6 @@ class EHRTrainer:
 
         if self.scheduler is not None:
             self.scheduler.step()
-        train_loop.set_postfix(loss=step_loss / self.accumulation_steps)
         epoch_loss.append(step_loss / self.accumulation_steps)
 
         if self.args["info"]:


### PR DESCRIPTION
Synchronous logging had the GPU hanging, resulting in spiky GPU utilization

Setting tqddm's postfix as train loss ignores the `miniters` and `mininterval` and prints every tqdm update. 

 