### PR TITLE
Fix/azure metrics

### DIFF
--- a/corebehrt/azure/util/azure.py
+++ b/corebehrt/azure/util/azure.py
@@ -21,7 +21,6 @@ def is_azure_available() -> bool:
 
     :return: True if available, otherwise False.
     """
-    global AZURE_AVAILABLE
     return AZURE_AVAILABLE
 
 

--- a/corebehrt/azure/util/config.py
+++ b/corebehrt/azure/util/config.py
@@ -61,6 +61,13 @@ def save_config(cfg_name: str, cfg: dict) -> None:
         yaml.dump(cfg, cfg_file)
 
 
+def to_yaml_str(cfg: dict) -> None:
+    """
+    Convert the given config to a nicely formatted yaml string
+    """
+    return yaml.dump(cfg)
+
+
 def load_job_config(cfg_name: str) -> "Config":  # noqa: F821
     """
     Load the config on the cluster

--- a/corebehrt/azure/util/job.py
+++ b/corebehrt/azure/util/job.py
@@ -9,6 +9,7 @@ from corebehrt.azure.util.config import (
     prepare_job_command_args,
     parse_args,
     save_config,
+    to_yaml_str,
     cleanup_configs,
 )
 from corebehrt.azure.util.test import evaluate_run
@@ -99,6 +100,9 @@ def setup(
     if test_cfg_file:
         cmd += f" --test {test_cfg_file}"
 
+    # Description = config as yaml in code block
+    description = "```\n" + to_yaml_str(config) + "```"
+
     # Create job
     from azure.ai.ml import command
 
@@ -110,6 +114,7 @@ def setup(
         outputs=output_values,
         environment="CoreBEHRT@latest",
         compute=compute,
+        description=description,
         name=f"{job}_{ts}",
     )
 

--- a/corebehrt/azure/util/log.py
+++ b/corebehrt/azure/util/log.py
@@ -22,7 +22,6 @@ def is_mlflow_available() -> bool:
     """
     Checks if mlflow module is available.
     """
-    global MLFLOW_AVAILABLE
     return MLFLOW_AVAILABLE
 
 
@@ -179,7 +178,6 @@ def log_batch(*args, **kwargs):
     :param metrics: metrics list
     """
     if is_mlflow_available():
-        global MLFLOW_CLIENT
         run, _ = get_run_and_prefix()
         MLFLOW_CLIENT.log_batch(*args, run_id=run.info.run_id, **kwargs)
 

--- a/corebehrt/azure/util/log.py
+++ b/corebehrt/azure/util/log.py
@@ -33,7 +33,6 @@ def start_run(name: str = None, nested: bool = False, log_system_metrics: bool =
     :param nested: If the run should be nested.
     :param log_system_metrics: If enabled, log system metrics (CPU/GPU/mem).
     """
-    global CURRENT_RUN
     if is_mlflow_available():
         run = mlflow.start_run(
             run_name=name, nested=nested, log_system_metrics=log_system_metrics

--- a/corebehrt/azure/util/log.py
+++ b/corebehrt/azure/util/log.py
@@ -71,7 +71,7 @@ def get_run_and_prefix() -> tuple:
         run = mlflow.active_run()
         prefix = ""
         while (parent := mlflow.get_parent_run(run.info.run_id)) is not None:
-            prefix += run.info.run_name + "."
+            prefix += run.info.run_name + "/"
             run = parent
         return run, prefix
 

--- a/corebehrt/azure/util/log.py
+++ b/corebehrt/azure/util/log.py
@@ -3,7 +3,6 @@ import time
 
 MLFLOW_AVAILABLE = False
 MLFLOW_CLIENT = None
-CURRENT_RUN = None
 
 try:
     # Try to import mlflow and set availability flag
@@ -23,14 +22,6 @@ def is_mlflow_available() -> bool:
     """
     global MLFLOW_AVAILABLE
     return MLFLOW_AVAILABLE
-
-
-def get_current_run():
-    """
-    Get the current run object, if available.
-    """
-    global CURRENT_RUN
-    return CURRENT_RUN
 
 
 def start_run(name: str = None, nested: bool = False, log_system_metrics: bool = False):
@@ -55,9 +46,6 @@ def start_run(name: str = None, nested: bool = False, log_system_metrics: bool =
             yield None
 
         run = dummy_cm()
-
-    if not nested:
-        CURRENT_RUN = run
 
     return run
 
@@ -164,7 +152,7 @@ def log_batch(*args, **kwargs):
     """
     if is_mlflow_available():
         global MLFLOW_CLIENT
-        run = get_current_run()
+        run = mlflow.active_run()
         MLFLOW_CLIENT.log_batch(*args, run_id=run.info.run_id, **kwargs)
 
 


### PR DESCRIPTION
* Added corebehrt job config to description to azure job, so it is visible in the dashboard.
* Changed child-run logging to use prefix instead of actual child runs. (The old functionality can be re-enabled by changing the global var in `azure/util/log.py`). This setup allows for nice comparison graphs within an experiment.

![2025-03-31-155439_1531x454_scrot](https://github.com/user-attachments/assets/44aca0a2-4739-4adc-a88f-6cb6d1f83c9d)
![2025-03-31-155453_455x390_scrot](https://github.com/user-attachments/assets/b9b050b9-ce26-444b-9968-26fbc91de9af)
![2025-03-31-155512_745x403_scrot](https://github.com/user-attachments/assets/af24f350-848c-4072-93d1-c3d913f4175c)

Closes #186
Closes #221 