### PR TITLE
bug fix in exclude regex

### DIFF
--- a/corebehrt/configs/create_data.yaml
+++ b/corebehrt/configs/create_data.yaml
@@ -9,7 +9,9 @@ paths:
   # optional
   # code_mapping: ./outputs/code_mapping.pt
   # vocabulary: ./outputs/vocabulary # vocab folder
-  
+
+# exclude_held_out: true # exclude held out patients data creation
+
 features:
   exclude_regex: ^(?:LAB).* # example regex to exclude all features that start with 'LAB'
   values:

--- a/corebehrt/main/create_data.py
+++ b/corebehrt/main/create_data.py
@@ -53,7 +53,12 @@ def main_data(config_path):
         logger.info("Reusing existing features")
     else:
         logger.info("Create and process features")
-        create_and_save_features(cfg)
+        if cfg.get("exclude_held_out", False):
+            logger.info("Excluding held out")
+            splits = ["train", "tuning"]
+        else:
+            splits = ["train", "tuning", "held_out"]
+        create_and_save_features(cfg, splits)
         logger.info("Finished feature creation and processing")
 
     logger.info("Tokenizing")

--- a/corebehrt/main/helper/create_data.py
+++ b/corebehrt/main/helper/create_data.py
@@ -17,6 +17,8 @@ from corebehrt.modules.features.features import FeatureCreator
 from corebehrt.modules.features.loader import FormattedDataLoader
 from corebehrt.modules.features.tokenizer import EHRTokenizer
 from corebehrt.modules.features.values import ValueCreator
+from corebehrt.functional.preparation.utils import is_valid_regex
+from corebehrt.functional.preparation.filter import filter_rows_by_regex
 
 
 def load_tokenize_and_save(
@@ -78,9 +80,12 @@ def create_and_save_features(cfg) -> None:
                     agg_window=agg_kwargs.get("agg_window", None),
                     regex=agg_kwargs.get("regex", None),
                 )
+            concepts = exclude_concepts(
+                concepts,
+                cfg.get("features", {}).get("exclude_regex", None),
+            )
             concepts = handle_numeric_values(concepts, cfg.get("features"))
-            exclude_regex = cfg.get("features", {}).get("exclude_regex", None)
-            feature_creator = FeatureCreator(exclude_regex=exclude_regex)
+            feature_creator = FeatureCreator()
             features, patient_info = feature_creator(concepts)
             combined_patient_info = pd.concat([combined_patient_info, patient_info])
             features = exclude_incorrect_event_ages(features)
@@ -91,6 +96,15 @@ def create_and_save_features(cfg) -> None:
             )
     patient_info_path = f"{cfg.paths.features}/patient_info.parquet"
     combined_patient_info.to_parquet(patient_info_path, index=False)
+
+
+def exclude_concepts(concepts, exclude_regex):
+    if exclude_regex is not None:
+        if not is_valid_regex(exclude_regex):
+            raise ValueError(f"Invalid regex: {exclude_regex}")
+        concepts = filter_rows_by_regex(concepts, col=CONCEPT_COL, regex=exclude_regex)
+        concepts = concepts.copy()  # to avoid SettingWithCopyWarning
+    return concepts
 
 
 def handle_aggregations(

--- a/corebehrt/main/helper/create_data.py
+++ b/corebehrt/main/helper/create_data.py
@@ -47,13 +47,13 @@ def load_tokenize_and_save(
     torch.save(set(pids), join(tokenized_path, f"pids_{split}.pt"))  # save pids as ints
 
 
-def create_and_save_features(cfg) -> None:
+def create_and_save_features(cfg, splits) -> None:
     """
     Creates features and saves them to disk.
     Returns a list of lists of pids for each batch
     """
     combined_patient_info = pd.DataFrame()
-    for split_name in ["train", "tuning", "held_out"]:
+    for split_name in splits:
         path_name = f"{cfg.paths.data}/{split_name}"
         if not os.path.exists(path_name):
             if split_name == "held_out":

--- a/corebehrt/modules/features/features.py
+++ b/corebehrt/modules/features/features.py
@@ -10,14 +10,15 @@ from corebehrt.functional.features.creators import (
 )
 from corebehrt.functional.features.exclude import exclude_event_nans
 from corebehrt.functional.setup.checks import check_features_columns
-from corebehrt.functional.preparation.filter import filter_rows_by_regex
 from corebehrt.constants.data import PID_COL
+
 
 class FeatureCreator:
     """
     A class to create features from patient information and concepts DataFrames.
     We create background, death, age, absolute position, and segments features.
     """
+
     def __call__(
         self,
         concepts: pd.DataFrame,

--- a/corebehrt/modules/features/features.py
+++ b/corebehrt/modules/features/features.py
@@ -11,31 +11,18 @@ from corebehrt.functional.features.creators import (
 from corebehrt.functional.features.exclude import exclude_event_nans
 from corebehrt.functional.setup.checks import check_features_columns
 from corebehrt.functional.preparation.filter import filter_rows_by_regex
-from corebehrt.constants.data import CONCEPT_COL, PID_COL
-from corebehrt.functional.preparation.utils import is_valid_regex
-
+from corebehrt.constants.data import PID_COL
 
 class FeatureCreator:
     """
     A class to create features from patient information and concepts DataFrames.
     We create background, death, age, absolute position, and segments features.
     """
-
-    def __init__(self, exclude_regex: str = None):
-        if exclude_regex is not None and not is_valid_regex(exclude_regex):
-            raise ValueError(f"Invalid regex: {exclude_regex}")
-        self.exclude_regex = exclude_regex
-
     def __call__(
         self,
         concepts: pd.DataFrame,
     ) -> pd.DataFrame:
         check_features_columns(concepts)
-        if self.exclude_regex is not None:
-            concepts = filter_rows_by_regex(
-                concepts, col=CONCEPT_COL, regex=self.exclude_regex
-            )
-            concepts = concepts.copy()  # to avoid SettingWithCopyWarning
         features, patient_info = create_background(concepts)
         features = create_age_in_years(features)
         features = create_abspos(features)


### PR DESCRIPTION
When excluding certain rows that match the exclude_regex, the corresponding values were not excluded (#230 ). 
I have now moved the exclusion of codes before the expansion of numeric values to deal with this. Also added an option for ignoring held_out data when performing data_creation. 