### PR TITLE
remove final separator token if present

### DIFF
--- a/corebehrt/functional/preparation/filter.py
+++ b/corebehrt/functional/preparation/filter.py
@@ -49,6 +49,7 @@ def exclude_short_sequences(
 ) -> List[PatientData]:
     return [p for p in patients if len(p.concepts) >= min_len]
 
+
 def _remove_last_sep_token(patient: PatientData) -> PatientData:
     """Remove the last single SEP token from the patient's data if it exists."""
     if patient.concepts[-1] == DEFAULT_VOCABULARY[SEP_TOKEN]:
@@ -57,6 +58,7 @@ def _remove_last_sep_token(patient: PatientData) -> PatientData:
         patient.segments = patient.segments[:-1]
         patient.ages = patient.ages[:-1]
     return patient
+
 
 def censor_patient(
     patient: PatientData, censor_dates: pd.Series, predict_token_id: int

--- a/corebehrt/functional/preparation/filter.py
+++ b/corebehrt/functional/preparation/filter.py
@@ -16,6 +16,8 @@ from corebehrt.modules.preparation.dataset import PatientData
 from corebehrt.constants.data import (
     PID_COL,
     TIMESTAMP_COL,
+    DEFAULT_VOCABULARY,
+    SEP_TOKEN,
 )
 
 
@@ -47,6 +49,14 @@ def exclude_short_sequences(
 ) -> List[PatientData]:
     return [p for p in patients if len(p.concepts) >= min_len]
 
+def _remove_last_sep_token(patient: PatientData) -> PatientData:
+    """Remove the last single SEP token from the patient's data if it exists."""
+    if patient.concepts[-1] == DEFAULT_VOCABULARY[SEP_TOKEN]:
+        patient.concepts = patient.concepts[:-1]
+        patient.abspos = patient.abspos[:-1]
+        patient.segments = patient.segments[:-1]
+        patient.ages = patient.ages[:-1]
+    return patient
 
 def censor_patient(
     patient: PatientData, censor_dates: pd.Series, predict_token_id: int
@@ -75,6 +85,7 @@ def censor_patient(
     patient.segments = patient.segments[:idx]
     patient.ages = patient.ages[:idx]
 
+    patient = _remove_last_sep_token(patient)
     patient = _append_predict_token(patient, predict_token_id, censor_date)
 
     return patient


### PR DESCRIPTION
When censoring if there exists a separator token as the last entry, then this leaks that the patient comes in after censoring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of patient data by ensuring that any trailing separator tokens are removed after censoring, leading to cleaner and more accurate data processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->