### PR TITLE
predict step

### DIFF
--- a/bonsai/modules/datamodules/FinetuneDataModule.py
+++ b/bonsai/modules/datamodules/FinetuneDataModule.py
@@ -13,7 +13,7 @@ class FinetuneDataModule(L.LightningDataModule):
         self,
         path_train_data: str,
         path_val_data: str,
-        path_test_data: str,
+        path_predict_data: str,
         path_population: str,
         batch_size: int,
         num_workers: int,
@@ -21,13 +21,13 @@ class FinetuneDataModule(L.LightningDataModule):
         max_len: int,
         train_outcomes: Dict[int, dict],
         val_outcomes: Dict[int, dict],
-        test_outcomes: Dict[int, dict],
+        predict_outcomes: Dict[int, dict],
         train_sampler: Optional[WeightedRandomSampler] = None,
     ):
         super().__init__()
         self.path_train_data = path_train_data
         self.path_val_data = path_val_data
-        self.path_test_data = path_test_data
+        self.path_predict_data = path_predict_data
         self.population = pl.read_csv(path_population)
 
         self.batch_size = batch_size
@@ -37,7 +37,7 @@ class FinetuneDataModule(L.LightningDataModule):
 
         self.train_outcomes = train_outcomes
         self.val_outcomes = val_outcomes
-        self.test_outcomes = test_outcomes
+        self.predict_outcomes = predict_outcomes
         self.train_sampler = train_sampler
 
     def setup(self, stage: Literal["fit", "test", "predict"]):
@@ -80,18 +80,18 @@ class FinetuneDataModule(L.LightningDataModule):
         )
 
     def setup_predict(self):
-        if self.path_test_data is None:
-            raise ValueError("path_test_data must be set before running predict.")
-        test_data = torch.load(self.path_test_data)
-        test_data = [
-            sub for sub in test_data if sub["subject_id"] in self.test_outcomes
+        if self.path_predict_data is None:
+            raise ValueError("path_predict_data must be set before running predict.")
+        predict_data = torch.load(self.path_predict_data)
+        predict_data = [
+            sub for sub in predict_data if sub["subject_id"] in self.predict_outcomes
         ]
         population_subject_ids = self.population["subject_id"].to_list()
-        test_data = filter_subject_data(test_data, population_subject_ids)
-        background_length = (test_data[0]["segment"] == 0).sum()
+        predict_data = filter_subject_data(predict_data, population_subject_ids)
+        background_length = (predict_data[0]["segment"] == 0).sum()
         self.predict_dataset = FinetuneDataset(
-            test_data,
-            outcomes=self.test_outcomes,
+            predict_data,
+            outcomes=self.predict_outcomes,
             predict_token_id=self.predict_token_id,
             background_length=background_length,
             max_len=self.max_len,

--- a/bonsai/modules/datamodules/FinetuneDataModule.py
+++ b/bonsai/modules/datamodules/FinetuneDataModule.py
@@ -13,6 +13,7 @@ class FinetuneDataModule(L.LightningDataModule):
         self,
         path_train_data: str,
         path_val_data: str,
+        path_test_data: str,
         path_population: str,
         batch_size: int,
         num_workers: int,
@@ -26,6 +27,7 @@ class FinetuneDataModule(L.LightningDataModule):
         super().__init__()
         self.path_train_data = path_train_data
         self.path_val_data = path_val_data
+        self.path_test_data = path_test_data
         self.population = pl.read_csv(path_population)
 
         self.batch_size = batch_size
@@ -44,7 +46,7 @@ class FinetuneDataModule(L.LightningDataModule):
         elif stage == "test":
             raise NotImplementedError("Test stage not supported for PretrainModule.")
         elif stage == "predict":
-            raise NotImplementedError("Predict stage not supported for PretrainModule.")
+            self.setup_predict()
 
     def setup_fit(self):
         train_data = torch.load(self.path_train_data)
@@ -77,6 +79,24 @@ class FinetuneDataModule(L.LightningDataModule):
             max_len=self.max_len,
         )
 
+    def setup_predict(self):
+        if self.path_test_data is None:
+            raise ValueError("path_test_data must be set before running predict.")
+        test_data = torch.load(self.path_test_data)
+        test_data = [
+            sub for sub in test_data if sub["subject_id"] in self.test_outcomes
+        ]
+        population_subject_ids = self.population["subject_id"].to_list()
+        test_data = filter_subject_data(test_data, population_subject_ids)
+        background_length = (test_data[0]["segment"] == 0).sum()
+        self.predict_dataset = FinetuneDataset(
+            test_data,
+            outcomes=self.test_outcomes,
+            predict_token_id=self.predict_token_id,
+            background_length=background_length,
+            max_len=self.max_len,
+        )
+
     def train_dataloader(self):
         return DataLoader(
             self.train_dataset,
@@ -92,6 +112,18 @@ class FinetuneDataModule(L.LightningDataModule):
     def val_dataloader(self):
         return DataLoader(
             self.val_dataset,
+            num_workers=self.num_workers,
+            batch_size=self.batch_size,
+            pin_memory=True,
+            persistent_workers=True,
+            drop_last=True,
+            shuffle=False,
+            collate_fn=dynamic_padding,
+        )
+
+    def predict_dataloader(self):
+        return DataLoader(
+            self.predict_dataset,
             num_workers=self.num_workers,
             batch_size=self.batch_size,
             pin_memory=True,

--- a/bonsai/modules/datamodules/FinetuneDataModule.py
+++ b/bonsai/modules/datamodules/FinetuneDataModule.py
@@ -128,7 +128,7 @@ class FinetuneDataModule(L.LightningDataModule):
             batch_size=self.batch_size,
             pin_memory=True,
             persistent_workers=True,
-            drop_last=True,
+            drop_last=False,
             shuffle=False,
             collate_fn=dynamic_padding,
         )

--- a/bonsai/modules/lightningmodules/FinetuneModule.py
+++ b/bonsai/modules/lightningmodules/FinetuneModule.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from os.path import join
 from typing import Optional
 
 import lightning as L
@@ -19,15 +20,13 @@ class FinetuneModule(L.LightningModule):
         learning_rate: float = 5e-4,
         optimizer_epsilon: float = 1e-6,
         scheduler_warmup_epochs: int = 0,
-        predictions_path: Optional[Path] = None,
-        test_metrics_path: Optional[Path] = None,
+        predictions_output_path: Optional[Path] = None,
     ):
         super().__init__()
         self.learning_rate = learning_rate
         self.optimizer_epsilon = optimizer_epsilon
         self.scheduler_warmup_epochs = scheduler_warmup_epochs
-        self.predictions_path = predictions_path
-        self.test_metrics_path = test_metrics_path
+        self.predictions_output_path = predictions_output_path
 
         self.model = model
         if compile_mode is not None:
@@ -37,6 +36,7 @@ class FinetuneModule(L.LightningModule):
         self.train_metrics = self.configure_metrics("train")
         self.val_metrics = self.configure_metrics("val")
         self.test_metrics = self.configure_metrics("test")
+        self.predict_metrics = self.configure_metrics("predict")
         hparams = model.config.to_dict()
         hparams.update(
             {
@@ -98,7 +98,7 @@ class FinetuneModule(L.LightningModule):
         labels = batch["target"]
         logits = self.model(batch)
         probs = torch.sigmoid(logits)
-        if self.predictions_path is not None or self.test_metrics_path is not None:
+        if self.predictions_output_path is not None:
             self.logits.append(logits.squeeze(-1))
             self.labels.append(labels.squeeze(-1))
             self.subject_ids.append(batch["subject_id"])
@@ -111,14 +111,14 @@ class FinetuneModule(L.LightningModule):
         }
 
     def on_predict_epoch_end(self) -> None:
-        if self.predictions_path is None and self.test_metrics_path is None:
+        if self.predictions_output_path is None:
             return
 
         logits = torch.cat([x.detach().cpu().float() for x in self.logits])
         labels = torch.cat([x.detach().cpu().long() for x in self.labels])
 
-        if self.predictions_path is not None:
-            self.predictions_path.parent.mkdir(parents=True, exist_ok=True)
+        if self.predictions_output_path is not None:
+            self.predictions_output_path.mkdir(parents=True, exist_ok=True)
             pl.DataFrame(
                 {
                     "subject_id": torch.cat(
@@ -130,16 +130,16 @@ class FinetuneModule(L.LightningModule):
                     ),
                     "label": labels,
                 }
-            ).write_csv(self.predictions_path)
+            ).write_csv(join(self.predictions_output_path, "predictions.csv"))
 
-        if self.test_metrics_path is not None:
-            self.test_metrics.reset()
-            metrics = self.test_metrics(logits, labels)
+            self.predict_metrics.reset()
+            metrics = self.predict_metrics(logits, labels)
             metrics = {
                 key: float(value.detach().cpu()) for key, value in metrics.items()
             }
-            self.test_metrics_path.parent.mkdir(parents=True, exist_ok=True)
-            pl.DataFrame(metrics).write_csv(self.test_metrics_path)
+            pl.DataFrame(metrics).write_csv(
+                join(self.predictions_output_path, "predict_metrics.csv")
+            )
 
     def configure_optimizers(self):
         optimizer = AdamW(

--- a/bonsai/modules/lightningmodules/FinetuneModule.py
+++ b/bonsai/modules/lightningmodules/FinetuneModule.py
@@ -136,8 +136,7 @@ class FinetuneModule(L.LightningModule):
             self.test_metrics.reset()
             metrics = self.test_metrics(logits, labels)
             metrics = {
-                key: float(value.detach().cpu())
-                for key, value in metrics.items()
+                key: float(value.detach().cpu()) for key, value in metrics.items()
             }
             self.test_metrics_path.parent.mkdir(parents=True, exist_ok=True)
             pl.DataFrame(metrics).write_csv(self.test_metrics_path)

--- a/bonsai/modules/lightningmodules/FinetuneModule.py
+++ b/bonsai/modules/lightningmodules/FinetuneModule.py
@@ -1,4 +1,8 @@
+from pathlib import Path
+from typing import Optional
+
 import lightning as L
+import polars as pl
 import torch
 from torch import nn
 from torch.optim import AdamW
@@ -15,11 +19,15 @@ class FinetuneModule(L.LightningModule):
         learning_rate: float = 5e-4,
         optimizer_epsilon: float = 1e-6,
         scheduler_warmup_epochs: int = 0,
+        predictions_path: Optional[Path] = None,
+        test_metrics_path: Optional[Path] = None,
     ):
         super().__init__()
         self.learning_rate = learning_rate
         self.optimizer_epsilon = optimizer_epsilon
         self.scheduler_warmup_epochs = scheduler_warmup_epochs
+        self.predictions_path = predictions_path
+        self.test_metrics_path = test_metrics_path
 
         self.model = model
         if compile_mode is not None:
@@ -79,6 +87,60 @@ class FinetuneModule(L.LightningModule):
         logits, _ = self.model(batch)
         self.test_metrics(logits, labels)
         self.log_dict(self.test_metrics, on_step=True, on_epoch=True)
+
+    def on_predict_epoch_start(self) -> None:
+        self.predictions = []
+        self.labels = []
+        self.subject_ids = []
+        self.logits = []
+
+    def predict_step(self, batch, batch_idx, dataloader_idx=0):
+        labels = batch["target"]
+        logits = self.model(batch)
+        probs = torch.sigmoid(logits)
+        if self.predictions_path is not None or self.test_metrics_path is not None:
+            self.logits.append(logits.squeeze(-1))
+            self.labels.append(labels.squeeze(-1))
+            self.subject_ids.append(batch["subject_id"])
+            self.predictions.append(probs.squeeze(-1))
+        return {
+            "subject_id": batch["subject_id"],
+            "logit": logits.squeeze(-1),
+            "prob": probs.squeeze(-1),
+            "label": labels.squeeze(-1),
+        }
+
+    def on_predict_epoch_end(self) -> None:
+        if self.predictions_path is None and self.test_metrics_path is None:
+            return
+
+        logits = torch.cat([x.detach().cpu().float() for x in self.logits])
+        labels = torch.cat([x.detach().cpu().long() for x in self.labels])
+
+        if self.predictions_path is not None:
+            self.predictions_path.parent.mkdir(parents=True, exist_ok=True)
+            pl.DataFrame(
+                {
+                    "subject_id": torch.cat(
+                        [x.detach().cpu() for x in self.subject_ids]
+                    ),
+                    "logit": logits,
+                    "prob": torch.cat(
+                        [x.detach().cpu().float() for x in self.predictions]
+                    ),
+                    "label": labels,
+                }
+            ).write_csv(self.predictions_path)
+
+        if self.test_metrics_path is not None:
+            self.test_metrics.reset()
+            metrics = self.test_metrics(logits, labels)
+            metrics = {
+                key: float(value.detach().cpu())
+                for key, value in metrics.items()
+            }
+            self.test_metrics_path.parent.mkdir(parents=True, exist_ok=True)
+            pl.DataFrame(metrics).write_csv(self.test_metrics_path)
 
     def configure_optimizers(self):
         optimizer = AdamW(

--- a/bonsai/run/finetune.py
+++ b/bonsai/run/finetune.py
@@ -52,7 +52,7 @@ def main(cfg: DictConfig) -> None:
     outcomes = outcomes.with_columns(
         censor_abspos=compute_abspos(pl.col("censor_date"))
     )
-    train_outcomes, val_outcomes, test_outcomes = split_and_binarize_outcomes(
+    train_outcomes, val_outcomes, predict_outcomes = split_and_binarize_outcomes(
         outcomes,
         train_key="train",
         val_key="tuning",
@@ -67,11 +67,11 @@ def main(cfg: DictConfig) -> None:
         num_workers=cfg.hardware.num_workers,
         path_train_data=cfg.paths.train_split,
         path_val_data=cfg.paths.val_split,
-        path_test_data=cfg.paths.test_split,
+        path_predict_data=cfg.paths.predict_split,
         path_population=cfg.paths.population,
         train_outcomes=train_outcomes,
         val_outcomes=val_outcomes,
-        test_outcomes=test_outcomes,
+        predict_outcomes=predict_outcomes,
         predict_token_id=vocab["[CLS]"],
         max_len=cfg.training.max_len,
         train_sampler=get_sampler(
@@ -130,19 +130,15 @@ def main(cfg: DictConfig) -> None:
         datamodule=data_module,
         ckpt_path=cfg.paths.ckpt_path,
     )
-    if cfg.paths.test_split is not None:
-        predictions_path = Path(model_save_dir) / "test_predictions.csv"
-        test_metrics_path = Path(model_save_dir) / "test_metrics.csv"
-        lightning_module.predictions_path = predictions_path
-        lightning_module.test_metrics_path = test_metrics_path
+    if cfg.paths.predict_split is not None:
+        predictions_output_path = Path(model_save_dir) / "test_predictions"
+        lightning_module.predictions_output_path = predictions_output_path
         trainer.predict(
             model=lightning_module,
             datamodule=data_module,
             ckpt_path="best",
         )
-        print(f"Saved predictions to {predictions_path}")
-        print(f"Saved test metrics to {test_metrics_path}")
-
+        print(f"Saved predictions to {predictions_output_path}")
 
 # TODO: Aggregate scores here, assuming test has been run after each training and test outputs some file.
 

--- a/bonsai/run/finetune.py
+++ b/bonsai/run/finetune.py
@@ -1,4 +1,5 @@
 import polars as pl
+from pathlib import Path
 import hydra
 import lightning as L
 import torch
@@ -66,6 +67,7 @@ def main(cfg: DictConfig) -> None:
         num_workers=cfg.hardware.num_workers,
         path_train_data=cfg.paths.train_split,
         path_val_data=cfg.paths.val_split,
+        path_test_data=cfg.paths.test_split,
         path_population=cfg.paths.population,
         train_outcomes=train_outcomes,
         val_outcomes=val_outcomes,
@@ -128,6 +130,18 @@ def main(cfg: DictConfig) -> None:
         datamodule=data_module,
         ckpt_path=cfg.paths.ckpt_path,
     )
+    if cfg.paths.test_split is not None:
+        predictions_path = Path(model_save_dir) / "test_predictions.csv"
+        test_metrics_path = Path(model_save_dir) / "test_metrics.csv"
+        lightning_module.predictions_path = predictions_path
+        lightning_module.test_metrics_path = test_metrics_path
+        trainer.predict(
+            model=lightning_module,
+            datamodule=data_module,
+            ckpt_path="best",
+        )
+        print(f"Saved predictions to {predictions_path}")
+        print(f"Saved test metrics to {test_metrics_path}")
 
 
 # TODO: Aggregate scores here, assuming test has been run after each training and test outputs some file.

--- a/bonsai/run/finetune.py
+++ b/bonsai/run/finetune.py
@@ -140,6 +140,7 @@ def main(cfg: DictConfig) -> None:
         )
         print(f"Saved predictions to {predictions_output_path}")
 
+
 # TODO: Aggregate scores here, assuming test has been run after each training and test outputs some file.
 
 

--- a/bonsai/run/train.py
+++ b/bonsai/run/train.py
@@ -43,7 +43,7 @@ def main(cfg: DictConfig) -> None:
     outcomes = outcomes.with_columns(
         censor_abspos=compute_abspos(pl.col("censor_date"))
     )
-    train_outcomes, val_outcomes, test_outcomes = split_and_binarize_outcomes(
+    train_outcomes, val_outcomes, predict_outcomes = split_and_binarize_outcomes(
         outcomes,
         train_key="train",
         val_key="tuning",
@@ -58,11 +58,11 @@ def main(cfg: DictConfig) -> None:
         num_workers=cfg.hardware.num_workers,
         path_train_data=cfg.paths.train_split,
         path_val_data=cfg.paths.val_split,
-        path_test_data=cfg.paths.test_split,
+        path_predict_data=cfg.paths.predict_split,
         path_population=cfg.paths.population,
         train_outcomes=train_outcomes,
         val_outcomes=val_outcomes,
-        test_outcomes=test_outcomes,
+        predict_outcomes=predict_outcomes,
         predict_token_id=vocab["[CLS]"],
         max_len=cfg.training.max_len,
         train_sampler=get_sampler(
@@ -120,18 +120,15 @@ def main(cfg: DictConfig) -> None:
         ckpt_path=cfg.paths.ckpt_path,
     )
 
-    if cfg.paths.test_split is not None:
-        predictions_path = Path(model_save_dir) / "test_predictions.csv"
-        test_metrics_path = Path(model_save_dir) / "test_metrics.csv"
-        lightning_module.predictions_path = predictions_path
-        lightning_module.test_metrics_path = test_metrics_path
+    if cfg.paths.predict_split is not None:
+        predictions_output_path = Path(model_save_dir) / "test_predictions"
+        lightning_module.predictions_output_path = predictions_output_path
         trainer.predict(
             model=lightning_module,
             datamodule=data_module,
             ckpt_path="best",
         )
-        print(f"Saved predictions to {predictions_path}")
-        print(f"Saved test metrics to {test_metrics_path}")
+        print(f"Saved predictions to {predictions_output_path}")
 
 
 # TODO: Aggregate scores here, assuming test has been run after each training and test outputs some file.

--- a/bonsai/run/train.py
+++ b/bonsai/run/train.py
@@ -1,4 +1,5 @@
 import polars as pl
+from pathlib import Path
 import hydra
 import lightning as L
 import torch
@@ -57,6 +58,7 @@ def main(cfg: DictConfig) -> None:
         num_workers=cfg.hardware.num_workers,
         path_train_data=cfg.paths.train_split,
         path_val_data=cfg.paths.val_split,
+        path_test_data=cfg.paths.test_split,
         path_population=cfg.paths.population,
         train_outcomes=train_outcomes,
         val_outcomes=val_outcomes,
@@ -117,6 +119,19 @@ def main(cfg: DictConfig) -> None:
         datamodule=data_module,
         ckpt_path=cfg.paths.ckpt_path,
     )
+
+    if cfg.paths.test_split is not None:
+        predictions_path = Path(model_save_dir) / "test_predictions.csv"
+        test_metrics_path = Path(model_save_dir) / "test_metrics.csv"
+        lightning_module.predictions_path = predictions_path
+        lightning_module.test_metrics_path = test_metrics_path
+        trainer.predict(
+            model=lightning_module,
+            datamodule=data_module,
+            ckpt_path="best",
+        )
+        print(f"Saved predictions to {predictions_path}")
+        print(f"Saved test metrics to {test_metrics_path}")
 
 
 # TODO: Aggregate scores here, assuming test has been run after each training and test outputs some file.

--- a/configs/finetune.yaml
+++ b/configs/finetune.yaml
@@ -11,7 +11,7 @@ paths:
   dir: ${oc.env:BONSAI_PROCESSED_DATA}/${dataset}
   train_split: ${paths.dir}/subject_data_train.pt
   val_split: ${paths.dir}/subject_data_tuning.pt
-  test_split: ${paths.dir}/subject_data_held_out.pt
+  predict_split: ${paths.dir}/subject_data_held_out.pt
   outcome: ${paths.dir}/outcomes/${outcome}.parquet
   vocabulary: ${paths.dir}/vocabulary.pt
   population: ${paths.dir}/population_full.csv

--- a/configs/finetune.yaml
+++ b/configs/finetune.yaml
@@ -11,11 +11,11 @@ paths:
   dir: ${oc.env:BONSAI_PROCESSED_DATA}/${dataset}
   train_split: ${paths.dir}/subject_data_train.pt
   val_split: ${paths.dir}/subject_data_tuning.pt
+  test_split: ${paths.dir}/subject_data_held_out.pt
   outcome: ${paths.dir}/outcomes/${outcome}.parquet
   vocabulary: ${paths.dir}/vocabulary.pt
   population: ${paths.dir}/population_full.csv
   ckpt_path: 
-
 
 data:
   shuffle: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full `predict`-stage support for running inference on a configurable held-out split after training.
  * You can optionally save per-sample prediction outputs and aggregated prediction metrics to CSV files.
  * Training and finetuning workflows now generate and persist predictions automatically when a prediction split is provided.  
* **Configuration**
  * Introduced a new `predict_split` path in `configs/finetune.yaml` for held-out evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->